### PR TITLE
fix: replace erroneous entry on template file

### DIFF
--- a/templates/munin.conf
+++ b/templates/munin.conf
@@ -100,7 +100,7 @@ contact.someuser.command mail -s "Munin notification" {{ munin__email_notificati
 
 # Group by domain
 {% for h in groups['all'] %}
-{%   if 'ansible_default_ipv4' in hostvars[h] and hostvars[h]['munin__client_configure'] %}
+{%   if 'ansible_default_ipv4' in hostvars[h] and hostvars[h]['ansible_default_ipv4'] %}
 [{{ h }}]
     use_node_name yes
 {%     if inventory_hostname == h %}
@@ -115,7 +115,7 @@ contact.someuser.command mail -s "Munin notification" {{ munin__email_notificati
     update no
 
 [{{ munin__main_group }};]
-    node_order Totals{% for host in groups['all'] %}{% if 'ansible_default_ipv4' in hostvars[host] and hostvars[host]['munin__client_configure']%} {{ host }}{% endif %}{% endfor %}
+    node_order Totals{% for host in groups['all'] %}{% if 'ansible_default_ipv4' in hostvars[host] and hostvars[host]['ansible_default_ipv4']%} {{ host }}{% endif %}{% endfor %}
 
 
 # a simple host tree


### PR DESCRIPTION
Update erroneous `munin__client_configure` entry using `hostvars` variable