### PR TITLE
fix: Allow local network access to Munin nodes

### DIFF
--- a/templates/munin-node.conf
+++ b/templates/munin-node.conf
@@ -41,7 +41,8 @@ host_name {{ ansible_fqdn }}
 # network notation unless the perl module Net::CIDR is installed.  You
 # may repeat the allow line as many times as you'd like
 
-allow ^192\.168\.56\..*$
+{% set netaddr = munin__internal_network.split("/")[0] %}
+allow ^{{ netaddr.split(".")[0] }}\.{{ netaddr.split(".")[1] }}\.{{ netaddr.split(".")[2] }}\..*$
 allow ^127\.0\.0\.1$
 allow ^::1$
 


### PR DESCRIPTION
This PR compute a network pattern (based on `255.255.255.0` netmask for now) to allow node gathering accesses