### PR TITLE
feature: Include support for SSL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Role Variables
 * `munin__webserver_strategy` defines the html and graph page generation stragegy 
 * `munin__email_notification` who should be notified
 * `munin__main_group` Default server group (ie internal domain)
+* `munin__use_ssl` Configure SSL (default: False)
+* `munin__ssl_cert` Path of certificate file
+* `munin__ssl_key` Path of certificate key file
+* `munin__ssl_dhparam` Path of dhparam file
+* `munin__ssl_includefile` Path of specific inclusion file
+
 
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,4 @@ munin__default_client_packages:
 # Can be apache, nginx or others
 munin__webserver: ""
 munin__fcgi_enabled: False
+munin__use_ssl: False

--- a/templates/vhost.conf
+++ b/templates/vhost.conf
@@ -1,8 +1,8 @@
 # munin monitoring server configuration
 #
 server {
-	listen 80;
-	listen [::]:80;
+	listen {% if munin__use_ssl %}443 ssl{% else %}80{% endif %};
+	listen [::]:{% if munin__use_ssl %}443 ssl{% else %}80{% endif %} ipv6only=on;
 	server_name {{ munin__hostname }};
 
 	# SSL configuration
@@ -20,7 +20,14 @@ server {
 	# Don't use them in a production server!
 	#
 	# include snippets/snakeoil.conf;
-
+{% if munin__use_ssl %}
+        ssl_certificate {{ munin__ssl_cert }};
+        ssl_certificate_key {{ munin__ssl_key }};
+	ssl_dhparam {{ munin__ssl_dhparam }};
+{%   if munin__ssl_includefile %}
+	include {{ munin__ssl_includefile }};
+{%   endif %}
+{% endif %}
 	root /var/cache/munin/www;
 	index index.html;
 
@@ -61,3 +68,17 @@ server {
 	#	deny all;
 	#}
 }
+{% if munin__use_ssl %}
+
+server {
+   if ($host = {{ munin__hostname }}) {
+       return 301 https://$host$request_uri;
+   }
+
+
+	listen 80;
+	listen [::]:80 ipv6only=on;
+	server_name {{ munin__hostname }};
+   return 404;
+}
+{% endif %}


### PR DESCRIPTION
Use `munin__use_ssl` to activate SSL support in configuration file