### PR TITLE
Fix: Specify internal IP on hypervisors

### DIFF
--- a/templates/munin.conf
+++ b/templates/munin.conf
@@ -105,6 +105,8 @@ contact.someuser.command mail -s "Munin notification" {{ munin__email_notificati
     use_node_name yes
 {%     if inventory_hostname == h %}
     address 127.0.0.1
+{%     elif 'ansible_virtualization_role' in hostvars[h] and hostvars[h]['ansible_virtualization_role'] == 'host' %}
+    address {{ hostvars[h]['ansible_all_ipv4_addresses'][0] }}
 {%     else %}
     address {{ hostvars[h]['ansible_default_ipv4']['address'] }}
 {%     endif %}


### PR DESCRIPTION
Munin should access to internal IP addresses of Xen hosters (firewall restrictions)