### PR TITLE
Fix: Include nginx timeouts for fast-cgi

### DIFF
--- a/templates/vhost.conf
+++ b/templates/vhost.conf
@@ -5,6 +5,12 @@ server {
 	listen [::]:{% if munin__use_ssl %}443 ssl{% else %}80{% endif %} ipv6only=on;
 	server_name {{ munin__hostname }};
 
+{% if munin__webserver_timeouts is defined %}
+{% for k,v in munin__webserver_timeouts.items() %}
+        proxy_{{ k }}_timeout {{ v }};
+{% endfor %}
+{% endif %}
+
 	# SSL configuration
 	#
 	# listen 443 ssl default_server;


### PR DESCRIPTION
Because fast-cgi can be long, we need to include timeouts management